### PR TITLE
Add U.S. Census Geocoding API in Python

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -151,6 +151,16 @@ parts:
         title: "...in Unix Shell"
 
 
+  - caption: GIS
+    chapters:
+
+    # U.S. Census Geocoding
+    - file: content/scripts/A_overview/census-geocoding_overview
+      sections:
+      - file: content/scripts/python/python_census-geocoding
+        title: "...in Python"
+        
+
   - caption: HUMANITIES
     chapters:
 

--- a/content/scripts/A_overview/census-geocoding_overview.rst
+++ b/content/scripts/A_overview/census-geocoding_overview.rst
@@ -1,0 +1,17 @@
+U.S. Census Geocoding
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+.. sectionauthor:: Michael T. Moen <mtmoen@crimson.ua.edu>
+
+Brief Overview
+****************
+
+The U.S. Census Geocoding Services API allows users to obtain geographic information for U.S. addresses. An API key is not required to access this API.
+
+See the API documentation [#uscg1]_ for more information on accessing the API. Please see the U.S. Census Bureau APIs terms of service [#uscg2]_ for specific information about API policies, data reuse, and allowed use-cases.
+
+.. rubric:: References
+
+.. [#uscg1] `<https://geocoding.geo.census.gov/geocoder/Geocoding_Services_API.html>`_
+
+.. [#uscg2] `<https://www.census.gov/data/developers/about/terms-of-service.html>`_

--- a/content/scripts/python/python_census-geocoding.ipynb
+++ b/content/scripts/python/python_census-geocoding.ipynb
@@ -1,0 +1,533 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# U.S. Census Geocoding API in Python\n",
+    "\n",
+    "by Michael T. Moen\n",
+    "\n",
+    "**U.S. Census Geocoding API documentation:** https://geocoding.geo.census.gov/geocoder/Geocoding_Services_API.html\n",
+    "\n",
+    "**U.S. Census Bureau APIs terms of use:** https://www.census.gov/data/developers/about/terms-of-service.html\n",
+    "\n",
+    "This product uses the Census Bureau Data API but is not endorsed or certified by the Census Bureau.\n",
+    "\n",
+    "*These recipe examples were tested on February 29, 2024.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import Libraries\n",
+    "\n",
+    "This tutorial uses the following libraries:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests             # Manages API requests\n",
+    "import csv                  # Facilitates reading and writing to CSV files    \n",
+    "from pprint import pprint   # Formats code outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Address Lookup\n",
+    "\n",
+    "One of the main use cases of this API is finding the latitude and longitude of an address. In this example, we find the latitude and longitude of the Bruno Business Library at the University of Alabama.\n",
+    "\n",
+    "The API allows searching through two methods: `address` and `onelineaddress`. These methods are nearly identical, with the only difference being the format of the parameters passed to API.\n",
+    "\n",
+    "### Using `address` Search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "200"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "return_type = 'locations'\n",
+    "search_type = 'address'\n",
+    "\n",
+    "parameters = '&'.join([\n",
+    "\n",
+    "    # Specify the address to lookup with the following parameters\n",
+    "    'street=425 Stadium Dr',\n",
+    "    'city=Tuscaloosa',\n",
+    "    'state=AL',\n",
+    "    'zip=35401',\n",
+    "\n",
+    "    # Specify the version of the locator to be searched\n",
+    "    'benchmark=Public_AR_Current',\n",
+    "\n",
+    "    # Specify that data should be returned in JSON format\n",
+    "    'format=json'\n",
+    "])\n",
+    "\n",
+    "url = f'https://geocoding.geo.census.gov/geocoder/{return_type}/{search_type}?{parameters}'\n",
+    "response = requests.get(url)\n",
+    "\n",
+    "# Status code of 200 indicates success\n",
+    "response.status_code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'result': {'input': {'address': {'zip': '35401',\n",
+       "    'city': 'Tuscaloosa',\n",
+       "    'street': '425 Stadium Dr',\n",
+       "    'state': 'AL'},\n",
+       "   'benchmark': {'isDefault': True,\n",
+       "    'benchmarkDescription': 'Public Address Ranges - Current Benchmark',\n",
+       "    'id': '4',\n",
+       "    'benchmarkName': 'Public_AR_Current'}},\n",
+       "  'addressMatches': [{'tigerLine': {'side': 'L', 'tigerLineId': '636109874'},\n",
+       "    'coordinates': {'x': -87.54970041625674, 'y': 33.21105403378043},\n",
+       "    'addressComponents': {'zip': '35401',\n",
+       "     'streetName': 'STADIUM',\n",
+       "     'preType': '',\n",
+       "     'city': 'TUSCALOOSA',\n",
+       "     'preDirection': '',\n",
+       "     'suffixDirection': '',\n",
+       "     'fromAddress': '401',\n",
+       "     'state': 'AL',\n",
+       "     'suffixType': 'DR',\n",
+       "     'toAddress': '499',\n",
+       "     'suffixQualifier': '',\n",
+       "     'preQualifier': ''},\n",
+       "    'matchedAddress': '425 STADIUM DR, TUSCALOOSA, AL, 35401'}]}}"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(-87.54970041625674, 33.21105403378043)"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "latitude = response.json()['result']['addressMatches'][0]['coordinates']['x']\n",
+    "longitude = response.json()['result']['addressMatches'][0]['coordinates']['y']\n",
+    "\n",
+    "# Display coordinates\n",
+    "latitude, longitude"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using `onelineaddress` Search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "200"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "return_type = 'locations'\n",
+    "search_type = 'onelineaddress'\n",
+    "\n",
+    "parameters = '&'.join([\n",
+    "\n",
+    "    # Specify the address to lookup with the parameters\n",
+    "    # Note that 'street' is required, and the other parameters are optional\n",
+    "    'address=425 Stadium Dr, Tuscaloosa, AL 35401',\n",
+    "\n",
+    "    # Specify the version of the locator to be searched\n",
+    "    'benchmark=Public_AR_Current',\n",
+    "\n",
+    "    # Specify that data should be returned in JSON format\n",
+    "    'format=json'\n",
+    "])\n",
+    "\n",
+    "url = f'https://geocoding.geo.census.gov/geocoder/{return_type}/{search_type}?{parameters}'\n",
+    "response = requests.get(url)\n",
+    "\n",
+    "# Status code of 200 indicates success\n",
+    "response.status_code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(-87.54970041625674, 33.21105403378043)"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "latitude = response.json()['result']['addressMatches'][0]['coordinates']['x']\n",
+    "longitude = response.json()['result']['addressMatches'][0]['coordinates']['y']\n",
+    "\n",
+    "# Display coordinates\n",
+    "latitude, longitude"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Batch Address Lookup\n",
+    "\n",
+    "The U.S. Census Geocoding API also allows for batch geocoding with the submission of a CSV, TXT, DAT, XLS, or XLSX file. These files must be formatted with one record per line, where each record must be formatted as followed: Unique ID, Street address, City, State, ZIP. Users are limited to 10,000 records per batch file.\n",
+    "\n",
+    "This example uses the CSV file created below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create list of addresses for the batch lookup\n",
+    "# Note that each record must begin with a unique ID\n",
+    "addresses = []\n",
+    "addresses.append(['1', '425 Stadium Dr', 'Tuscaloosa', 'AL', '35401'])\n",
+    "addresses.append(['2', '1600 Pennsylvania Avenue NW', 'Washington', 'DC', '20500'])\n",
+    "addresses.append(['3', '350 Fifth Avenue', 'New York', 'NY', '10118'])\n",
+    "addresses.append(['4', '660 Cannery Row', 'Monterey', 'CA', '93940'])\n",
+    "addresses.append(['5', '700 Clark Ave', 'St. Louis', 'MO', '63102'])\n",
+    "\n",
+    "# Export addresses to a CSV file\n",
+    "input_filename = 'batch_addresses.csv'\n",
+    "with open(input_filename, 'w', newline='') as f:\n",
+    "    csv_writer = csv.writer(f)\n",
+    "    csv_writer.writerows(addresses)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "200"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Format parameters needed for POST request\n",
+    "return_type = 'locations'\n",
+    "parameters = {\n",
+    "    'benchmark' : 'Public_AR_Current'\n",
+    "}\n",
+    "files = {\n",
+    "    'addressFile': open(input_filename, \"rb\")\n",
+    "}\n",
+    "\n",
+    "url = f'https://geocoding.geo.census.gov/geocoder/{return_type}/addressbatch'\n",
+    "response = requests.post(url, data=parameters, files=files)\n",
+    "\n",
+    "# Status code of 200 indicates success\n",
+    "response.status_code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['1', '425 Stadium Dr, Tuscaloosa, AL, 35401', 'Match', 'Exact', '425 STADIUM DR, TUSCALOOSA, AL, 35401', '-87.54970041625677,33.211054033780556', '636109874', 'L']\n",
+      "['2', '1600 Pennsylvania Avenue NW, Washington, DC, 20500', 'Match', 'Exact', '1600 PENNSYLVANIA AVE NW, WASHINGTON, DC, 20500', '-77.03654395730786,38.89869091865552', '76225813', 'L']\n",
+      "['3', '350 Fifth Avenue, New York, NY, 10118', 'Match', 'Exact', '350 5TH AVE, NEW YORK, NY, 10118', '-73.98507715289111,40.747848600317354', '59653473', 'L']\n",
+      "['4', '660 Cannery Row, Monterey, CA, 93940', 'Match', 'Exact', '660 CANNERY ROW, MONTEREY, CA, 93940', '-121.90128030457356,36.617235842516266', '647390330', 'R']\n",
+      "['5', '700 Clark Ave, St. Louis, MO, 63102', 'Match', 'Non_Exact', '700 CLARK AVE, SAINT LOUIS, MO, 63119', '-90.34036943803642,38.60242241714883', '100141071', 'R']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Save content of response to a new CSV\n",
+    "output_filename = 'geocoded_addresses.csv'\n",
+    "with open(output_filename, 'wb') as f:\n",
+    "    f.write(response.content)\n",
+    "\n",
+    "# Printing contents of CSV for demonstation purposes\n",
+    "with open(output_filename, newline='') as f:\n",
+    "    csv_reader = csv.reader(f)\n",
+    "    for row in csv_reader:\n",
+    "        print(row)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the last two columns of the above data are the TIGER/Line ID and TIGER/Line Side. For more information on these values, please see the [U.S. Census TIGER/Line Geodatabase Documentation](https://www.census.gov/programs-surveys/geography/technical-documentation/complete-technical-documentation/tiger-geodatabase-file.html). However, this tutorial does not utilize any TIGER/Line data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Retrieving Additional Geographic Data\n",
+    "\n",
+    "The `geographies` return type allows for the retrieval of additional data associated for a given address or set of coordinates. The example below retrieves this data using the address of the Bruno Business Library at the University of Alabama.\n",
+    "\n",
+    "Note that the `geographies` return type requires the `vintage` parameter to be specified.\n",
+    "\n",
+    "Users may additionally include the `layers` parameter, which determines the types of geography data returned. For a list of all layers, see [here](https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_Current/MapServer)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "200"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "return_type = 'geographies'\n",
+    "search_type = 'address'\n",
+    "\n",
+    "parameters = '&'.join([\n",
+    "\n",
+    "    # Specify the address to lookup with the following parameters\n",
+    "    'street=425 Stadium Dr',\n",
+    "    'city=Tuscaloosa',\n",
+    "    'state=AL',\n",
+    "    'zip=35401',\n",
+    "\n",
+    "    # Specify the version of the locator to be searched\n",
+    "    'benchmark=Public_AR_Current',\n",
+    "\n",
+    "    # Specify the vintage\n",
+    "    'vintage=Current_Current',\n",
+    "\n",
+    "    # Specify what categories of geographic data to retrieve\n",
+    "    'layers=all',\n",
+    "\n",
+    "    # Specify that data should be returned in JSON format\n",
+    "    'format=json'\n",
+    "])\n",
+    "\n",
+    "url = f'https://geocoding.geo.census.gov/geocoder/{return_type}/{search_type}?{parameters}'\n",
+    "response = requests.get(url)\n",
+    "\n",
+    "# Status code of 200 indicates success\n",
+    "response.status_code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the `geographies` return type returns all of the data that the `locations` return type does in addition to the geographies data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'addressComponents': {...},\n",
+      " 'coordinates': {...},\n",
+      " 'geographies': {...},\n",
+      " 'matchedAddress': '425 STADIUM DR, TUSCALOOSA, AL, 35401',\n",
+      " 'tigerLine': {...}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(response.json()['result']['addressMatches'][0], depth=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The geographies data contains the following categories:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'118th Congressional Districts': [...],\n",
+      " '2020 Census Blocks': [...],\n",
+      " '2020 Census Public Use Microdata Areas': [...],\n",
+      " '2020 Census ZIP Code Tabulation Areas': [...],\n",
+      " '2022 State Legislative Districts - Lower': [...],\n",
+      " '2022 State Legislative Districts - Upper': [...],\n",
+      " 'Census Block Groups': [...],\n",
+      " 'Census Divisions': [...],\n",
+      " 'Census Regions': [...],\n",
+      " 'Census Tracts': [...],\n",
+      " 'Counties': [...],\n",
+      " 'County Subdivisions': [...],\n",
+      " 'Incorporated Places': [...],\n",
+      " 'Metropolitan Statistical Areas': [...],\n",
+      " 'States': [...],\n",
+      " 'Unified School Districts': [...],\n",
+      " 'Urban Areas': [...]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(response.json()['result']['addressMatches'][0]['geographies'], depth=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As an example, this is how the Counties data is formatted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'GEOID': '01125',\n",
+       "  'CENTLAT': '+33.2894031',\n",
+       "  'AREAWATER': 78703449,\n",
+       "  'STATE': '01',\n",
+       "  'BASENAME': 'Tuscaloosa',\n",
+       "  'OID': '2759075608325',\n",
+       "  'LSADC': '06',\n",
+       "  'FUNCSTAT': 'A',\n",
+       "  'INTPTLAT': '+33.2902197',\n",
+       "  'NAME': 'Tuscaloosa County',\n",
+       "  'OBJECTID': 598,\n",
+       "  'CENTLON': '-087.5250366',\n",
+       "  'COUNTYCC': 'H1',\n",
+       "  'COUNTYNS': '00161588',\n",
+       "  'AREALAND': 3420980038,\n",
+       "  'INTPTLON': '-087.5227834',\n",
+       "  'MTFCC': 'G4020',\n",
+       "  'COUNTY': '125'}]"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response.json()['result']['addressMatches'][0]['geographies']['Counties']"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "cookbook-env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.1"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/content/scripts/python/python_nws.ipynb
+++ b/content/scripts/python/python_nws.ipynb
@@ -85,7 +85,9 @@
     "\n",
     "The NWS publishes weather forecasts for each of its Weather Forecast Offices. A map of these offices and the regions they cover can be found here: https://www.weather.gov/srh/nwsoffices\n",
     "\n",
-    "In order to obtain the forecast for a location, we must query that region's Weather Forecast Office using its code and the grid coordinates of the location. To determine these values for a location, we can query the `/points` endpoint."
+    "In order to obtain the forecast for a location, we must query that region's Weather Forecast Office using its code and the grid coordinates of the location. To determine these values for a location, we can query the `/points` endpoint.\n",
+    "\n",
+    "*To see how to programmatically obtain the latititude and longitude of an address in the U.S., please see our [U.S. Census Geocoding cookbook tutorials](https://ualibweb.github.io/UALIB_ScholarlyAPI_Cookbook/content/scripts/A_overview/census-geocoding_overview.html).*"
    ]
   },
   {

--- a/content/scripts/python/python_pubchem-periodic-table.ipynb
+++ b/content/scripts/python/python_pubchem-periodic-table.ipynb
@@ -20,20 +20,14 @@
     "\n",
     "These recipe examples were tested on February 23, 2024.\n",
     "\n",
-    "**_NOTE:_** The PubChem limits requests to a maximum of 5 requests per second."
+    "**_NOTE:_** The PubChem Periodic Table API limits requests to a maximum of 5 requests per second."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Setup\n",
-    "\n",
-    "### API Key Information\n",
-    "\n",
-    "An API key is not required to access the PubChem\n",
-    "\n",
-    "### Import Libraries\n",
+    "## Import Libraries\n",
     "\n",
     "This tutorial uses the following libraries:"
    ]


### PR DESCRIPTION
In addition to adding the tutorial, I
- Added a link to the overview from the NWS tutorial
- Fixed a typo and formatting error in the PubChem Periodic Table tutorial